### PR TITLE
Add missing YieldReady for Twig Node

### DIFF
--- a/src/Twig/Node.php
+++ b/src/Twig/Node.php
@@ -2,10 +2,12 @@
 
 namespace NotFloran\MjmlBundle\Twig;
 
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Node\CaptureNode;
 use Twig\Node\Node as Twig_Node;
 
+#[YieldReady]
 class Node extends Twig_Node
 {
     /**


### PR DESCRIPTION
Fix #96

I forgot `#[YieldReady]` in #94.