### PR TITLE
Use 'Extension' under 'DependencyInjection' component

### DIFF
--- a/src/DependencyInjection/MjmlExtension.php
+++ b/src/DependencyInjection/MjmlExtension.php
@@ -7,8 +7,8 @@ use NotFloran\MjmlBundle\Renderer\RendererInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class MjmlExtension extends Extension
 {


### PR DESCRIPTION
The old `Symfony\Component\HttpKernel\DependencyInjection\Extension` class is considered internal since Symfony 7.1, to be deprecated in 8.1. According to the official deprecation message, we should use `Symfony\Component\DependencyInjection\Extension\Extension` instead.

I have tested it, and I can confirm that there is no deprecation message, while MJML continues to work perfectly as before. Additionally, `Symfony\Component\DependencyInjection\Extension\Extension` has existed since Symfony 3, so I don't think there is a need to implement compatibility code.

Fixed #98
