### PR TITLE
Do not pass "$tag" parameter to Twig_Node constructor

### DIFF
--- a/src/Twig/Node.php
+++ b/src/Twig/Node.php
@@ -16,12 +16,20 @@ class Node extends Twig_Node
      */
     public function __construct(Twig_Node $value, $line, $tag = null)
     {
+        $twigGreaterThan312 = version_compare(\Twig\Environment::VERSION, '3.12', '>=');
+
         if (class_exists(CaptureNode::class)) {
-            $value = new CaptureNode($value, $line, $tag);
+            $value = $twigGreaterThan312
+                ? new CaptureNode($value, $line)
+                : new CaptureNode($value, $line, $tag);
             $value->setAttribute('raw', true);
         }
 
-        parent::__construct(['value' => $value], ['name' => $tag], $line, $tag);
+        if ($twigGreaterThan312) {
+            parent::__construct(['value' => $value], ['name' => $tag], $line);
+        } else {
+            parent::__construct(['value' => $value], ['name' => $tag], $line, $tag);
+        }
     }
 
     /**


### PR DESCRIPTION
> Since twig/twig 3.12: The "tag" constructor argument of the "NotFloran\MjmlBundle\Twig\Node" class is deprecated and ignored (check which TokenParser class set it to "mjml"), the tag is now automatically set by the Parser when needed.

Therefore, I select the constructor according to the Twig version (since you accept the Twig version less than 3.12):

- If the environment Twig version is greater than (or equal to) 3.12, we don't pass `$tag`.
- Otherwise, we pass it like we used to do.

I have dogfood it and have not see anything wrong. The deprecation message indeed disappeared.

Fixed #100
