### PR TITLE
Prevent deprecated (explicit nullable type) notice with PHP 8.4

### DIFF
--- a/src/Renderer/BinaryRenderer.php
+++ b/src/Renderer/BinaryRenderer.php
@@ -34,7 +34,7 @@ final class BinaryRenderer implements RendererInterface
      */
     private $node;
 
-    public function __construct(string $bin, bool $minify, string $validationLevel, string $node = null, int $mjmlVersion = null)
+    public function __construct(string $bin, bool $minify, string $validationLevel, ?string $node = null, ?int $mjmlVersion = null)
     {
         $this->bin = $bin;
         $this->minify = $minify;


### PR DESCRIPTION
Hi,

This is a small PR to address the following deprecation notice:

> ( ! ) Deprecated: NotFloran\MjmlBundle\Renderer\BinaryRenderer::__construct(): Implicitly marking parameter $node as nullable is deprecated, the explicit nullable type must be used instead in /Users/sylvainlegleau/Devs/anct/symfony-aei/vendor/notfloran/mjml-bundle/src/Renderer/BinaryRenderer.php on line 37

Thanks for your work!

